### PR TITLE
SPIDR-1230 | Reduce suggest index build time for author, publisher, and ISBN

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.5.4</version>
+  <version>1.5.5</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/OReillySuggestionDocSetFilter.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/OReillySuggestionDocSetFilter.java
@@ -1,0 +1,98 @@
+package com.ifactory.press.db.solr.spelling.suggest;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FieldValueQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.solr.search.DocSet;
+import org.apache.solr.search.SolrIndexSearcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+/*
+ * A wrapper class for filtering docs used for suggestions on a general level specific to each suggestion index.
+ * Instead of applying specific filter queries, this class applies Lucene Queries to the given SolrIndexSearcher
+ * to determine which DocSet is most appropriate for each suggestion index, to avoid scanning all docs on suggest build
+ * when easily possible. If no specific case is matched, a DocSet consisting of all docs is used.
+ * Note: The business logic in this class is specific to O'Reilly Media's use case.
+ */
+public class OReillySuggestionDocSetFilter {
+  private List<MultiSuggester.WeightedField> suggestFields;
+  private String suggestFieldName;
+  private SolrIndexSearcher searcher;
+  private Query filteredDocSetQuery;
+  private String EXCLUDE_FILTERING_FIELD = "title"; // The only single field that will be excluded from filtering
+
+  private static final Logger LOG = LoggerFactory.getLogger(OReillySuggestionDocSetFilter.class);
+
+  public OReillySuggestionDocSetFilter(List<MultiSuggester.WeightedField> suggestFields, SolrIndexSearcher searcher) {
+    this.suggestFields = suggestFields;
+    this.searcher = searcher;
+    this.filteredDocSetQuery = new MatchAllDocsQuery();  // By default, use all docs
+    if (isFilteredSuggestField()) {
+      suggestFieldName = suggestFields.get(0).fieldName;
+    }
+  }
+
+  public List<MultiSuggester.WeightedField> getSuggestFields() {
+    return suggestFields;
+  }
+
+  public void setSuggestFields(List<MultiSuggester.WeightedField> suggestFields) {
+    this.suggestFields = suggestFields;
+  }
+
+  public SolrIndexSearcher getSearcher() {
+    return searcher;
+  }
+
+  public void setSearcher(SolrIndexSearcher searcher) {
+    this.searcher = searcher;
+  }
+
+  public String getSuggestFieldName() {
+    return suggestFieldName;
+  }
+
+  public void setSuggestFieldName(String suggestFieldName) {
+    this.suggestFieldName = suggestFieldName;
+  }
+
+  public DocSet getFilteredDocSet() throws IOException {
+    setAppropriateFilterDocSetQuery();
+    return searcher.getDocSet(filteredDocSetQuery);
+  }
+
+  public boolean isFilteredSuggestField() {
+    return suggestFields != null
+        && suggestFields.size() == 1
+        && !suggestFields.get(0).fieldName.equals(EXCLUDE_FILTERING_FIELD);
+  }
+
+  private void setAppropriateFilterDocSetQuery() {
+    if (isFilteredSuggestField()) {
+      LOG.info(String.format("Retrieving filtered DocSet for field: %s", suggestFieldName));
+      switch (suggestFieldName) {
+        case "authors":
+          filteredDocSetQuery = new TermQuery(new Term("content_type", "author"));
+          suggestFieldName = "id";    // Author names stored in 'id' in author index
+          break;
+        case "publishers":
+          filteredDocSetQuery = new TermQuery(new Term("content_type", "publisher"));
+          suggestFieldName = "id";    // Publisher names stored in 'id' in publisher index
+          break;
+        case "isbn":
+          filteredDocSetQuery = new FieldValueQuery("isbn");  // Filters any docs without isbn field
+          break;
+        default:
+          LOG.info(String.format("No case matched for fieldName: %s. Using all docs.", suggestFieldName));
+          filteredDocSetQuery = new MatchAllDocsQuery();  // Default to matching all docs
+          break;
+      }
+    }
+  }
+}

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SuggestDocIterator.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SuggestDocIterator.java
@@ -1,0 +1,50 @@
+package com.ifactory.press.db.solr.spelling.suggest;
+
+import org.apache.solr.search.DocIterator;
+import java.util.NoSuchElementException;
+
+public class SuggestDocIterator implements DocIterator {
+
+  /*
+   * A wrapper Iterator that either uses the DocIterator supplied during initialization
+   * or iterates through all doc ids between 0 and supplied maxDoc (similar to a simple for-loop fashion)
+   */
+
+  private int maxDoc;
+  private int currentDocId;
+  private DocIterator docSetIterator;
+
+  public SuggestDocIterator(DocIterator docSetIterator, Integer maxDoc) {
+    this.docSetIterator = docSetIterator;
+    this.maxDoc = maxDoc;
+    this.currentDocId = 0;
+  }
+
+  public boolean shouldScanAllDocs() {
+    return docSetIterator == null;  // If no custom DocIterator configured, scan all docs
+  }
+
+  @Override
+  public int nextDoc() {
+    if (!hasNext()) {
+      throw new NoSuchElementException("There are no remaining documents to be retrieved.");
+    }
+    return shouldScanAllDocs() ? ++currentDocId : docSetIterator.nextDoc();
+  }
+
+  @Override
+  public Integer next() {
+    return nextDoc();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return shouldScanAllDocs() ? currentDocId < maxDoc - 1 : docSetIterator.hasNext();
+  }
+
+  @Override
+  public float score() {
+    // Irrelevant for our use case, implementation needed for abstract method.
+    return 0;
+  }
+}

--- a/src/test/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggesterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggesterTest.java
@@ -113,6 +113,9 @@ public class MultiSuggesterTest extends SolrTest {
     return solr.query(q);
   }
 
+
+  // ********************** Tests ***************************
+
   /*
    * HERO-2705
    */
@@ -308,33 +311,6 @@ public class MultiSuggesterTest extends SolrTest {
   }
 
   @Test
-  public void testOverrideAnalyzer() throws Exception {
-    rebuildSuggester();
-    assertNoSuggestions();
-    insertTestDocuments(TITLE_VALUE_FIELD);
-    assertSuggestions();
-    assertSuggestionCount("a1", 1, "title");
-    rebuildSuggester();
-    assertSuggestions();
-    assertSuggestionCount("a1", 1, "title");
-  }
-
-  @Test
-  public void testAutocommit() throws Exception {
-    // TITLE
-    rebuildSuggester();
-    assertNoSuggestions();
-    int numDocs = 10;
-    insertTestDocuments(TITLE_VALUE_FIELD, numDocs, false);
-    Thread.sleep (500); // wait for autocommit
-    //solr.commit();
-    long numFound = solr.query(new SolrQuery("*:*")).getResults().getNumFound();
-    assertEquals (numDocs, numFound);
-    assertSuggestions();
-    assertSuggestionCount("a1", 1, "title");
-  }
-
-  @Test
   public void testDocFreqWeight() throws Exception {
     // ALL
     rebuildSuggester();
@@ -356,6 +332,30 @@ public class MultiSuggesterTest extends SolrTest {
     long t1 = System.nanoTime();
     assertSuggestionCount("a2", 11, "all");
     System.out.println("testDocFreqWeight: " + (t1 - t0) + " ns");
+  }
+
+  @Test
+  public void testOverrideAnalyzer() throws Exception {
+    rebuildSuggester();
+    assertNoSuggestions();
+    insertTestDocuments(TITLE_VALUE_FIELD);
+    assertSuggestions();
+    assertSuggestionCount("a1", 1, "title");
+  }
+
+  @Test
+  public void testAutocommit() throws Exception {
+    // TITLE
+    rebuildSuggester();
+    assertNoSuggestions();
+    int numDocs = 10;
+    insertTestDocuments(TITLE_VALUE_FIELD, numDocs, false);
+    Thread.sleep (500); // wait for autocommit
+    //solr.commit();
+    long numFound = solr.query(new SolrQuery("*:*")).getResults().getNumFound();
+    assertEquals (numDocs, numFound);
+    assertSuggestions();
+    assertSuggestionCount("a1", 1, "title");
   }
 
   /*


### PR DESCRIPTION
- Suggestions do not rebuild when servers restart if the `buildOnStartup` param is false.
- Author, Publisher, and ISBN suggest builds optimized to scan through a smaller list of only the relevant documents.

When they are all ran at the same time, the suggest build runtime on in-use Prod searchers looks like:
All: ~8 minutes
Title: ~8 minutes (still have to scan through most documents)
ISBN: 25 seconds
Author: 25 seconds
Publisher: <10 seconds