### PR TITLE
Return empty result instead of error when getting suggests during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.5.6</version>
+  <version>1.5.7</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -1,10 +1,7 @@
 package com.ifactory.press.db.solr.spelling.suggest;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DirectoryReader;
@@ -14,10 +11,13 @@ import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SafariInfixSuggester extends AnalyzingInfixSuggester {
 
   private final boolean highlight;
+  private static final Logger LOG = LoggerFactory.getLogger(SafariInfixSuggester.class);
 
   public enum Context {
     SHOW, HIDE
@@ -75,6 +75,10 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
    */
   @Override
   public List<LookupResult> lookup(CharSequence key, Set<BytesRef> contexts, boolean onlyMorePopular, int num) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
     if (contexts != null) {
       contexts.addAll(showContext);
     } else {


### PR DESCRIPTION
Instead of blowing up with an error when requesting suggestions (including through the `all` handler), Solr will respond with empty suggestion response. For example, if title suggestions are building, the `all` suggest handler will still return suggestions from other types, and just empty for titles.

```2019-10-18 18:16:08.874 INFO  (qtp1969969319-51) [   x:collection1] o.a.s.h.c.SuggestComponent SuggestComponent process with : q=java&indent=on&suggest.count=10&suggest=true&suggest.dictionary=suggester-title&suggest.dictionary=suggester-author&suggest.dictionary=suggester-publisher&suggest.dictionary=suggester-isbn&wt=json&_=1571422403054```

```2019-10-18 18:16:08.874 INFO  (qtp1969969319-51) [   x:collection1] c.i.p.d.s.s.s.SafariInfixSuggester Attempting to retrieve suggestions while suggest build in progress.```