### PR TITLE
V1.5.7 | Return 0 results, instead of errors, during suggest build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.5.6</version>
+  <version>1.5.7</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -5,6 +5,8 @@ import java.util.*;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.spell.Dictionary;
 import org.apache.lucene.search.suggest.InputIterator;
 import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
@@ -71,7 +73,8 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
   }
 
   /*
-   * disable highlighting
+      Override each possible lookup method from AnalyzingInfixSuggester to return empty results
+      if suggest build is in progress (instead of throwing error)
    */
   @Override
   public List<LookupResult> lookup(CharSequence key, Set<BytesRef> contexts, boolean onlyMorePopular, int num) throws IOException {
@@ -84,7 +87,71 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
     } else {
       contexts = showContext;
     }
-    return lookup(key, contexts, num, true, highlight);
+    return super.lookup(key, contexts, num, true, highlight);
+  }
+
+  public List<LookupResult> lookup(CharSequence key, int num, boolean allTermsRequired, boolean doHighlight) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
+    return super.lookup(key, (BooleanQuery)null, num, allTermsRequired, doHighlight);
+  }
+
+  public List<LookupResult> lookup(CharSequence key, Set<BytesRef> contexts, int num, boolean allTermsRequired, boolean doHighlight) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
+    return super.lookup(key, this.toQuery(contexts), num, allTermsRequired, doHighlight);
+  }
+
+  public List<LookupResult> lookup(CharSequence key, Map<BytesRef, BooleanClause.Occur> contextInfo, int num, boolean allTermsRequired, boolean doHighlight) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
+    return super.lookup(key, this.toQuery(contextInfo), num, allTermsRequired, doHighlight);
+  }
+
+  public List<LookupResult> lookup(CharSequence key, BooleanQuery contextQuery, int num, boolean allTermsRequired, boolean doHighlight) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
+    return super.lookup(key, contextQuery, num, allTermsRequired, doHighlight);
+  }
+
+  private BooleanQuery toQuery(Map<BytesRef, BooleanClause.Occur> contextInfo) {
+    if (contextInfo != null && !contextInfo.isEmpty()) {
+      BooleanQuery.Builder contextFilter = new BooleanQuery.Builder();
+      Iterator var3 = contextInfo.entrySet().iterator();
+
+      while(var3.hasNext()) {
+        Map.Entry<BytesRef, BooleanClause.Occur> entry = (Map.Entry)var3.next();
+        this.addContextToQuery(contextFilter, (BytesRef)entry.getKey(), (BooleanClause.Occur)entry.getValue());
+      }
+
+      return contextFilter.build();
+    } else {
+      return null;
+    }
+  }
+
+  private BooleanQuery toQuery(Set<BytesRef> contextInfo) {
+    if (contextInfo != null && !contextInfo.isEmpty()) {
+      BooleanQuery.Builder contextFilter = new BooleanQuery.Builder();
+      Iterator var3 = contextInfo.iterator();
+
+      while(var3.hasNext()) {
+        BytesRef context = (BytesRef)var3.next();
+        this.addContextToQuery(contextFilter, context, BooleanClause.Occur.SHOULD);
+      }
+
+      return contextFilter.build();
+    } else {
+      return null;
+    }
   }
 
   static class EmptyInputIterator implements InputIterator {

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -1,10 +1,7 @@
 package com.ifactory.press.db.solr.spelling.suggest;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DirectoryReader;
@@ -14,10 +11,13 @@ import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SafariInfixSuggester extends AnalyzingInfixSuggester {
 
   private final boolean highlight;
+  private static final Logger LOG = LoggerFactory.getLogger(SafariInfixSuggester.class);
 
   public enum Context {
     SHOW, HIDE
@@ -75,6 +75,10 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
    */
   @Override
   public List<LookupResult> lookup(CharSequence key, Set<BytesRef> contexts, boolean onlyMorePopular, int num) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
     if (contexts != null) {
       contexts.addAll(showContext);
     } else {


### PR DESCRIPTION
Overriding all of the `lookup` methods from the parent class `AnalyzingInfixSuggester` to add a safeguard against throwing errors when trying to look up suggestions while they are building (will return 0 results instead).

Example: If title suggest index is building, our `all` suggest handler will still return results from all of the other suggest indexes, and just 0 results for titles.

```2019-10-18 18:16:08.874 INFO (qtp1969969319-51) [ x:collection1] o.a.s.h.c.SuggestComponent SuggestComponent process with : q=java&indent=on&suggest.count=10&suggest=true&suggest.dictionary=suggester-title&suggest.dictionary=suggester-author&suggest.dictionary=suggester-publisher&suggest.dictionary=suggester-isbn&wt=json&_=1571422403054```

```2019-10-18 18:16:08.874 INFO (qtp1969969319-51) [ x:collection1] c.i.p.d.s.s.s.SafariInfixSuggester Attempting to retrieve suggestions while suggest build in progress.```