### PR TITLE
V1.5.7 | Bug fixes on SuggestComponent builds and lookups.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.5.6</version>
+  <version>1.5.7</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -5,6 +5,8 @@ import java.util.*;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.spell.Dictionary;
 import org.apache.lucene.search.suggest.InputIterator;
 import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
@@ -71,7 +73,8 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
   }
 
   /*
-   * disable highlighting
+      Override each possible lookup method from AnalyzingInfixSuggester to return empty results
+      if suggest build is in progress (instead of throwing error)
    */
   @Override
   public List<LookupResult> lookup(CharSequence key, Set<BytesRef> contexts, boolean onlyMorePopular, int num) throws IOException {
@@ -84,7 +87,71 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
     } else {
       contexts = showContext;
     }
-    return lookup(key, contexts, num, true, highlight);
+    return super.lookup(key, contexts, num, true, highlight);
+  }
+
+  public List<LookupResult> lookup(CharSequence key, int num, boolean allTermsRequired, boolean doHighlight) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
+    return super.lookup(key, (BooleanQuery)null, num, allTermsRequired, doHighlight);
+  }
+
+  public List<LookupResult> lookup(CharSequence key, Set<BytesRef> contexts, int num, boolean allTermsRequired, boolean doHighlight) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
+    return super.lookup(key, this.toQuery(contexts), num, allTermsRequired, doHighlight);
+  }
+
+  public List<LookupResult> lookup(CharSequence key, Map<BytesRef, BooleanClause.Occur> contextInfo, int num, boolean allTermsRequired, boolean doHighlight) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
+    return super.lookup(key, this.toQuery(contextInfo), num, allTermsRequired, doHighlight);
+  }
+
+  public List<LookupResult> lookup(CharSequence key, BooleanQuery contextQuery, int num, boolean allTermsRequired, boolean doHighlight) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
+    return super.lookup(key, contextQuery, num, allTermsRequired, doHighlight);
+  }
+
+  private BooleanQuery toQuery(Map<BytesRef, BooleanClause.Occur> contextInfo) {
+    if (contextInfo != null && !contextInfo.isEmpty()) {
+      BooleanQuery.Builder contextFilter = new BooleanQuery.Builder();
+      Iterator var3 = contextInfo.entrySet().iterator();
+
+      while(var3.hasNext()) {
+        Map.Entry<BytesRef, BooleanClause.Occur> entry = (Map.Entry)var3.next();
+        this.addContextToQuery(contextFilter, (BytesRef)entry.getKey(), (BooleanClause.Occur)entry.getValue());
+      }
+
+      return contextFilter.build();
+    } else {
+      return null;
+    }
+  }
+
+  private BooleanQuery toQuery(Set<BytesRef> contextInfo) {
+    if (contextInfo != null && !contextInfo.isEmpty()) {
+      BooleanQuery.Builder contextFilter = new BooleanQuery.Builder();
+      Iterator var3 = contextInfo.iterator();
+
+      while(var3.hasNext()) {
+        BytesRef context = (BytesRef)var3.next();
+        this.addContextToQuery(contextFilter, context, BooleanClause.Occur.SHOULD);
+      }
+
+      return contextFilter.build();
+    } else {
+      return null;
+    }
   }
 
   static class EmptyInputIterator implements InputIterator {

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -153,7 +153,7 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
     List<LookupResult> highlightedLookups = new ArrayList<LookupResult>();
     for(LookupResult lr : lookups) {
       if(lr.highlightKey != null) {
-        highlightedLookups.add(new LookupResult(lr.highlightKey.toString(), 1));
+        highlightedLookups.add(new LookupResult(lr.highlightKey.toString(), lr.highlightKey, lr.value, lr.payload, lr.contexts));
       }
     }
     return highlightedLookups;

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -1,10 +1,7 @@
 package com.ifactory.press.db.solr.spelling.suggest;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DirectoryReader;
@@ -14,10 +11,13 @@ import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SafariInfixSuggester extends AnalyzingInfixSuggester {
 
   private final boolean highlight;
+  private static final Logger LOG = LoggerFactory.getLogger(SafariInfixSuggester.class);
 
   public enum Context {
     SHOW, HIDE
@@ -75,6 +75,10 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
    */
   @Override
   public List<LookupResult> lookup(CharSequence key, Set<BytesRef> contexts, boolean onlyMorePopular, int num) throws IOException {
+    if (super.searcherMgr == null) {
+      LOG.info("Attempting to retrieve suggestions while suggest build in progress.");
+      return new ArrayList<>();
+    }
     if (contexts != null) {
       contexts.addAll(showContext);
     } else {

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -150,7 +150,7 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
       highlightedKey field regardless of highlight configurations.
    */
   private List<LookupResult> extractHighlightedLookups(List<LookupResult> lookups) {
-    List<LookupResult> highlightedLookups = new ArrayList<LookupResult>();
+    List<LookupResult> highlightedLookups = new ArrayList<>();
     for(LookupResult lr : lookups) {
       if(lr.highlightKey != null) {
         highlightedLookups.add(new LookupResult(lr.highlightKey.toString(), lr.highlightKey, lr.value, lr.payload, lr.contexts));
@@ -159,13 +159,15 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
     return highlightedLookups;
   }
 
+  // The following toQuery methods were taken directly from Lucene source code without modification,
+  // as AnalyzingInfixSuggester's toQuery methods are private and cannot be used here.
   private BooleanQuery toQuery(Map<BytesRef, BooleanClause.Occur> contextInfo) {
     if (contextInfo != null && !contextInfo.isEmpty()) {
       BooleanQuery.Builder contextFilter = new BooleanQuery.Builder();
-      Iterator var3 = contextInfo.entrySet().iterator();
+      Iterator contextIter = contextInfo.entrySet().iterator();
 
-      while(var3.hasNext()) {
-        Map.Entry<BytesRef, BooleanClause.Occur> entry = (Map.Entry)var3.next();
+      while(contextIter.hasNext()) {
+        Map.Entry<BytesRef, BooleanClause.Occur> entry = (Map.Entry)contextIter.next();
         this.addContextToQuery(contextFilter, (BytesRef)entry.getKey(), (BooleanClause.Occur)entry.getValue());
       }
 
@@ -178,10 +180,10 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
   private BooleanQuery toQuery(Set<BytesRef> contextInfo) {
     if (contextInfo != null && !contextInfo.isEmpty()) {
       BooleanQuery.Builder contextFilter = new BooleanQuery.Builder();
-      Iterator var3 = contextInfo.iterator();
+      Iterator contextIter = contextInfo.iterator();
 
-      while(var3.hasNext()) {
-        BytesRef context = (BytesRef)var3.next();
+      while(contextIter.hasNext()) {
+        BytesRef context = (BytesRef)contextIter.next();
         this.addContextToQuery(contextFilter, context, BooleanClause.Occur.SHOULD);
       }
 


### PR DESCRIPTION
Override `add` and all possible `lookup` methods from `AnalyzingInfixSuggester` to apply 3 improvements/bug fixes:
1. De-duplication during suggest build using Java's HashSet
2. Return highlighted suggestions if they exist in the LookupResult object
3. If a suggest build is in progress, just return 0 suggestions, instead of throwing an error. This is especially handy when requesting suggestions through the `all` suggest handler, which currently throws an error if any of the suggest indexes are currently building (now it will just return 0 suggestions for that specific suggest type).