### PR TITLE
SPIDR-1717 | Allow blocking suggest builds at the context level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.6.6</version>
+  <version>1.6.7</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>

--- a/solr/heron/conf/solrconfig.xml
+++ b/solr/heron/conf/solrconfig.xml
@@ -1221,220 +1221,120 @@ unless you are sure you always want it.
      -->
   
    <!-- Suggester -->
-  <searchComponent name="suggest-component" class="solr.SpellCheckComponent">
+  <searchComponent name="suggester" class="solr.SuggestComponent">
 
-    <!-- Multiple "Spell Checkers" can be declared and used by this
-         component
-      -->
+    <!-- Multiple suggesters can be configured with this SuggestComponent -->
 
-    <!-- a spellchecker built from a field of the main index -->
-    <lst name="spellchecker">
-      <str name="name">suggest-infix-all</str>
-      <!-- ignored -->
-      <!-- <str name="field">text</str> -->
-      <str name="classname">com.ifactory.press.db.solr.spelling.suggest.MultiSuggester</str>
+    <lst name="suggester">
+      <str name="name">suggester-title</str>
+
       <str name="lookupImpl">com.ifactory.press.db.solr.spelling.suggest.SafeInfixLookupFactory</str>
-      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggest-all</str>
+      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggester-title</str>
+      <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+      <str name="field">title</str>
       <str name="suggestAnalyzerFieldType">text_suggest</str>
-      <!--<float name="threshold">0.005</float>-->
-      <float name="threshold">0.0</float>
-      <!-- true == performance-killer. MultiSuggester handles incremental updates automatically, so there's no need for this anyway. -->
+      <str name="buildOnStartup">false</str>
       <str name="buildOnCommit">false</str>
-      <lst name="fields">
-        <lst name="field">
-          <str name="name">text</str>
-          <float name="weight">0.001</float>
-          <float name="minfreq">0.001</float>
-          <float name="maxfreq">0.3</float>
-        </lst>
-        <lst name="field">
-          <str name="name">query_kw</str>
-          <float name="weight">1.0</float>
-        </lst>
-        <lst name="field">
-          <str name="name">title</str>
-          <float name="weight">1.0</float>
-          <str name="analyzerFieldType">string</str>
-        </lst>
-        <lst name="field">
-          <str name="name">author</str>
-          <float name="weight">1.0</float>
-          <str name="analyzerFieldType">string</str>
-        </lst>
-        <lst name="field">
-          <str name="name">publisher</str>
-          <float name="weight">1.0</float>
-          <str name="analyzerFieldType">string</str>
-        </lst>
-        <lst name="field">
-          <str name="name">isbn</str>
-          <float name="weight">1.0</float>
-          <str name="analyzerFieldType">string</str>
-        </lst>
-      </lst>
+      <str name="highlight">true</str>
     </lst>
 
-    <lst name="spellchecker">
-      <str name="name">suggest-infix-author</str>
-      <lst name="fields">
-        <lst name="field">
-          <str name="name">author</str>
-          <str name="analyzerFieldType">string</str>
-          <float name="weight">2.0</float>
-        </lst>
-        <lst name="field">
-          <str name="name">author</str>
-          <float name="weight">1.0</float>
-        </lst>
-      </lst>
-      <str name="classname">com.ifactory.press.db.solr.spelling.suggest.MultiSuggester</str>
+    <lst name="suggester">
+      <str name="name">suggester-author</str>
+
       <str name="lookupImpl">com.ifactory.press.db.solr.spelling.suggest.SafeInfixLookupFactory</str>
-      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggest-author</str>
+      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggester-author</str>
+      <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+      <str name="field">title</str>
       <str name="suggestAnalyzerFieldType">text_suggest</str>
-      <float name="threshold">0.0</float>
+      <str name="buildOnStartup">false</str>
       <str name="buildOnCommit">false</str>
+      <str name="highlight">true</str>
     </lst>
 
-    <lst name="spellchecker">
-      <str name="name">suggest-infix-title</str>
-      <lst name="fields">
-        <lst name="field">
-          <str name="name">title</str>
-          <str name="analyzerFieldType">string</str>
-          <float name="weight">2.0</float>
-        </lst>
-        <lst name="field">
-          <str name="name">title</str>
-          <float name="weight">1.0</float>
-        </lst>
-      </lst>
-      <str name="classname">com.ifactory.press.db.solr.spelling.suggest.MultiSuggester</str>
+    <lst name="suggester">
+      <str name="name">suggester-publisher</str>
+
       <str name="lookupImpl">com.ifactory.press.db.solr.spelling.suggest.SafeInfixLookupFactory</str>
-      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggest-title</str>
+      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggester-publisher</str>
+      <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+      <str name="field">title</str>
       <str name="suggestAnalyzerFieldType">text_suggest</str>
-      <float name="threshold">0.0</float>
+      <str name="buildOnStartup">false</str>
       <str name="buildOnCommit">false</str>
+      <str name="highlight">true</str>
     </lst>
 
-    <lst name="spellchecker">
-      <str name="name">suggest-infix-publisher</str>
-      <lst name="fields">
-        <lst name="field">
-          <str name="name">publisher</str>
-          <str name="analyzerFieldType">string</str>
-          <float name="weight">2.0</float>
-        </lst>
-        <!-- FIXME: remove this workaround for a bug in ifpress-solr-plugin
-             once rev. 1.2.11 is deployed, and also for the other fields
-             below It indexes all the words as suggestions, in addition to
-             the whole field value.  The only reason we have it is because there
-             is an NPE if you don't have any word-based fields.
-        -->
-        <lst name="field">
-          <str name="name">publisher</str>
-          <float name="weight">1.0</float>
-        </lst>
-      </lst>
-      <str name="classname">com.ifactory.press.db.solr.spelling.suggest.MultiSuggester</str>
-      <str name="lookupImpl">com.ifactory.press.db.solr.spelling.suggest.SafeInfixLookupFactory</str>
-      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggest-publisher</str>
-      <str name="suggestAnalyzerFieldType">text_suggest</str>
-      <float name="threshold">0.0</float>
-      <str name="buildOnCommit">false</str>
-    </lst>
+    <lst name="suggester">
+      <str name="name">suggester-isbn</str>
 
-    <lst name="spellchecker">
-      <str name="name">suggest-infix-isbn</str>
-      <lst name="fields">
-        <lst name="field">
-          <str name="name">isbn</str>
-          <str name="analyzerFieldType">string</str>
-        </lst>
-        <lst name="field">
-          <str name="name">isbn</str>
-          <str name="analyzerFieldType">string</str>
-          <float name="weight">2.0</float>
-        </lst>
-        <lst name="field">
-          <str name="name">publisher</str>
-          <float name="weight">1.0</float>
-        </lst>
-      </lst>
-      <str name="classname">com.ifactory.press.db.solr.spelling.suggest.MultiSuggester</str>
       <str name="lookupImpl">com.ifactory.press.db.solr.spelling.suggest.SafeInfixLookupFactory</str>
-      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggest-isbn</str>
+      <str name="indexPath">${solr.core.instanceDir}/${solr.core.dataDir}/suggester-isbn</str>
+      <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+      <str name="field">title</str>
       <str name="suggestAnalyzerFieldType">text_suggest</str>
-      <float name="threshold">0.0</float>
+      <str name="buildOnStartup">false</str>
       <str name="buildOnCommit">false</str>
+      <str name="highlight">true</str>
     </lst>
-    
   </searchComponent>
 
-  <!-- A request handler for the Suggester -->
-  <requestHandler name="/suggest/all" class="solr.SearchHandler" startup="lazy">
+  <!-- Request handlers for the SuggestComponent Suggesters -->
+  <requestHandler name="/suggester/all" class="solr.SearchHandler" startup="lazy" >
     <lst name="defaults">
-      <str name="spellcheck">true</str>
-      <!-- order by frequency (otherwise alphabetically) -->
-      <str name="spellcheck.onlyMorePopular">true</str>
-      <str name="spellcheck.dictionary">suggest-infix-all</str>
-      <str name="spellcheck.count">10</str>
-      <!-- include a query incorporating the suggested term? -->
-      <!-- <str name="spellcheck.collate">true</str> -->
+      <str name="suggest">true</str>
+      <str name="suggest.count">10</str>
+      <!-- include all suggesters -->
+      <str name="suggest.dictionary">suggester-title</str>
+      <str name="suggest.dictionary">suggester-author</str>
+      <str name="suggest.dictionary">suggester-publisher</str>
+      <str name="suggest.dictionary">suggester-isbn</str>
     </lst>
     <arr name="components">
-      <str>suggest-component</str>
+      <str>suggester</str>
     </arr>
   </requestHandler>
 
-  <requestHandler name="/suggest/author" class="solr.SearchHandler" startup="lazy">
+  <requestHandler name="/suggester/title" class="solr.SearchHandler" startup="lazy" >
     <lst name="defaults">
-      <str name="spellcheck">true</str>
-      <!-- order by frequency (otherwise alphabetically) -->
-      <str name="spellcheck.onlyMorePopular">true</str>
-      <str name="spellcheck.dictionary">suggest-infix-author</str>
-      <str name="spellcheck.count">10</str>
+      <str name="suggest">true</str>
+      <str name="suggest.count">10</str>
+      <str name="suggest.dictionary">suggester-title</str>
     </lst>
     <arr name="components">
-      <str>suggest-component</str>
+      <str>suggester</str>
     </arr>
   </requestHandler>
 
-  <requestHandler name="/suggest/title" class="solr.SearchHandler" startup="lazy">
+  <requestHandler name="/suggester/author" class="solr.SearchHandler" startup="lazy" >
     <lst name="defaults">
-      <str name="spellcheck">true</str>
-      <!-- order by frequency (otherwise alphabetically) -->
-      <str name="spellcheck.onlyMorePopular">true</str>
-      <str name="spellcheck.dictionary">suggest-infix-title</str>
-      <str name="spellcheck.count">10</str>
+      <str name="suggest">true</str>
+      <str name="suggest.count">10</str>
+      <str name="suggest.dictionary">suggester-author</str>
     </lst>
     <arr name="components">
-      <str>suggest-component</str>
+      <str>suggester</str>
     </arr>
   </requestHandler>
 
-  <requestHandler name="/suggest/publisher" class="solr.SearchHandler" startup="lazy">
+  <requestHandler name="/suggester/publisher" class="solr.SearchHandler" startup="lazy" >
     <lst name="defaults">
-      <str name="spellcheck">true</str>
-      <!-- order by frequency (otherwise alphabetically) -->
-      <str name="spellcheck.onlyMorePopular">true</str>
-      <str name="spellcheck.dictionary">suggest-infix-publisher</str>
-      <str name="spellcheck.count">10</str>
+      <str name="suggest">true</str>
+      <str name="suggest.count">10</str>
+      <str name="suggest.dictionary">suggester-publisher</str>
     </lst>
     <arr name="components">
-      <str>suggest-component</str>
+      <str>suggester</str>
     </arr>
   </requestHandler>
 
-  <requestHandler name="/suggest/isbn" class="solr.SearchHandler" startup="lazy">
+  <requestHandler name="/suggester/isbn" class="solr.SearchHandler" startup="lazy" >
     <lst name="defaults">
-      <str name="spellcheck">true</str>
-      <!-- order by frequency (otherwise alphabetically) -->
-      <str name="spellcheck.onlyMorePopular">true</str>
-      <str name="spellcheck.dictionary">suggest-infix-isbn</str>
-      <str name="spellcheck.count">10</str>
+      <str name="suggest">true</str>
+      <str name="suggest.count">10</str>
+      <str name="suggest.dictionary">suggester-isbn</str>
     </lst>
     <arr name="components">
-      <str>suggest-component</str>
+      <str>suggester</str>
     </arr>
   </requestHandler>
 
@@ -1713,9 +1613,6 @@ unless you are sure you always want it.
 
   <!-- chain for MultiSuggesterProcessor -->
   <updateRequestProcessorChain name="suggester-update-chain" default="false">
-    <processor class="com.ifactory.press.db.solr.processor.MultiSuggesterProcessorFactory">
-      <str name="suggester-component">suggest-component</str>
-    </processor>
     <processor class="com.ifactory.press.db.solr.processor.UpdateDocValuesProcessorFactory" />
     <processor class="solr.LogUpdateProcessorFactory" />
     <processor class="solr.RunUpdateProcessorFactory" />

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggester.java
@@ -55,6 +55,10 @@ public class SafariInfixSuggester extends AnalyzingInfixSuggester {
 
   }
 
+  public Map<Suggestion, Long> getSuggestWeightMap() {
+    return suggestWeightMap;
+  }
+
   public void clear () throws IOException {
     super.build(new EmptyInputIterator());
   }

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafeInfixLookupFactory.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/SafeInfixLookupFactory.java
@@ -2,6 +2,7 @@ package com.ifactory.press.db.solr.spelling.suggest;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.suggest.Lookup;
@@ -13,6 +14,8 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.spelling.suggest.fst.AnalyzingInfixLookupFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is basically a copy-paste of AnalyzingInfixLookupFactory
@@ -24,11 +27,11 @@ public class SafeInfixLookupFactory extends AnalyzingInfixLookupFactory {
      * Default path where the index for the suggester is stored/loaded from
      * */
     private static final String DEFAULT_INDEX_PATH = "analyzingInfixSuggesterIndexDir";
-    
     private static final String HIGHLIGHT = "highlight";
-    
     private static final boolean DEFAULT_HIGHLIGHT = true;
-    
+    private static final String EXCLUDE_CONTEXTS = "excludeContexts";
+    private static final Logger LOG = LoggerFactory.getLogger(SafeInfixLookupFactory.class);
+
     @Override
     public Lookup create(@SuppressWarnings("rawtypes") NamedList params, SolrCore core) {
         // mandatory parameter
@@ -44,26 +47,25 @@ public class SafeInfixLookupFactory extends AnalyzingInfixLookupFactory {
         Analyzer queryAnalyzer = ft.getQueryAnalyzer();
   
         // optional parameters
-  
-        String indexPath = params.get(INDEX_PATH) != null ?
-                params.get(INDEX_PATH).toString() :
-                        DEFAULT_INDEX_PATH;
+        String indexPath = params.get(INDEX_PATH) != null ? params.get(INDEX_PATH).toString() : DEFAULT_INDEX_PATH;
   
         int minPrefixChars = params.get(MIN_PREFIX_CHARS) != null
-                ? Integer.parseInt(params.get(MIN_PREFIX_CHARS).toString())
-                        : AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS;
+            ? Integer.parseInt(params.get(MIN_PREFIX_CHARS).toString())
+            : AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS;
                 
         Boolean highlight = params.getBooleanArg(HIGHLIGHT);
+        List<String> excludedContexts = params.getAll(EXCLUDE_CONTEXTS);
+        LOG.info("\n\nIgnoring these contexts when building suggester: " + excludedContexts);
         if (highlight == null) {
             highlight = DEFAULT_HIGHLIGHT;
         }
 
-         try {
-             return new SafariInfixSuggester(FSDirectory.open(new File(indexPath).toPath()), indexAnalyzer,
-                                           queryAnalyzer, minPrefixChars, highlight);
-         } catch (IOException e) {
-             throw new SolrException(ErrorCode.SERVER_ERROR, e);
-         }
+        try {
+            return new SafariInfixSuggester(FSDirectory.open(new File(indexPath).toPath()), indexAnalyzer,
+                                           queryAnalyzer, minPrefixChars, highlight, excludedContexts);
+        } catch (IOException e) {
+            throw new SolrException(ErrorCode.SERVER_ERROR, e);
+        }
     }
 
 }

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/Suggestion.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/Suggestion.java
@@ -2,6 +2,7 @@ package com.ifactory.press.db.solr.spelling.suggest;
 
 import org.apache.lucene.util.BytesRef;
 
+import java.util.HashSet;
 import java.util.Set;
 
 public class Suggestion {
@@ -13,7 +14,7 @@ public class Suggestion {
 
   public Suggestion(BytesRef text, Set<BytesRef> contexts, long weight, BytesRef payload) {
     this.text = text != null ? text.utf8ToString() : null;
-    this.contexts = contexts;
+    this.contexts = contexts != null ? contexts : new HashSet<BytesRef>();
     this.weight = weight;
     this.payload = payload != null ? payload.utf8ToString() : null;
   }

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/Suggestion.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/Suggestion.java
@@ -19,6 +19,18 @@ public class Suggestion {
     this.payload = payload != null ? payload.utf8ToString() : null;
   }
 
+  public Suggestion(String rawText, String[] rawContexts, long weight, BytesRef payload) {
+    this.text = rawText;
+    this.contexts = new HashSet<>();
+    this.weight = weight;
+    this.payload = payload != null ? payload.utf8ToString() : null;
+    if(rawContexts != null) {
+      for (String context : rawContexts) {
+        contexts.add(new BytesRef(context));
+      }
+    }
+  }
+
   public String getText() {
     return text;
   }

--- a/src/test/java/com/ifactory/press/db/solr/HeronSolrTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/HeronSolrTest.java
@@ -1,37 +1,60 @@
 package com.ifactory.press.db.solr;
 
+import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 public class HeronSolrTest {
 
-    static CoreContainer coreContainer;
-    protected SolrClient solr;
+  static CoreContainer coreContainer;
+  protected SolrClient solr;
 
-    @Before
-    public void startup() throws IOException, SolrServerException {
-      // start an embedded solr instance
-      coreContainer = new CoreContainer("solr");
-      coreContainer.load();
-      solr = new EmbeddedSolrServer(coreContainer, "heron");
-      solr.deleteByQuery("*:*");
-      solr.commit();
-    }    
+  @BeforeClass
+  public static void startup() throws Exception {
+    FileUtils.cleanDirectory(new File("solr/heron/data/"));
+    // start an embedded solr instance
+    coreContainer = new CoreContainer("solr");
+    coreContainer.load();
+  }
 
-    @After
-    public void shutdown() throws Exception {
-        SolrCore core = coreContainer.getCore("heron");
-        if (core != null) {
-            core.close();
-        }
-        coreContainer.shutdown();
-    }    
+  @AfterClass
+  public static void shutdown() throws Exception {
+    SolrCore core = getDefaultCore();
+    if (core != null) {
+      core.close();
+    }
+    coreContainer.shutdown();
+    FileUtils.cleanDirectory(new File("solr/heron/data/"));
+    coreContainer = null;
+  }
+
+  @Before
+  public void init() throws Exception {
+    solr = new EmbeddedSolrServer(coreContainer, "heron");
+    clearIndex();
+  }
+
+  protected void clearIndex () throws SolrServerException, IOException {
+    solr.deleteByQuery("*:*");
+    solr.commit(true, true, false);
+  }
+
+  protected static SolrCore getDefaultCore() {
+    return coreContainer.getCore("heron");
+  }
+
+  @After
+  public void cleanup() throws Exception {
+  }
 
 }

--- a/src/test/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggesterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/spelling/suggest/MultiSuggesterTest.java
@@ -3,6 +3,7 @@ package com.ifactory.press.db.solr.spelling.suggest;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.store.Directory;
@@ -209,7 +210,7 @@ public class MultiSuggesterTest extends SolrTest {
     MultiDictionary dict = new MultiDictionary();
     WhitespaceAnalyzer analyzer = new WhitespaceAnalyzer();
     Directory dir = new RAMDirectory();
-    SafariInfixSuggester s = new SafariInfixSuggester(dir, analyzer, analyzer, 1, true);
+    SafariInfixSuggester s = new SafariInfixSuggester(dir, analyzer, analyzer, 1, true, new ArrayList<String>());
     try {
       s.build(dict);
       assertTrue(s.lookup("", false, 1).isEmpty());

--- a/src/test/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggesterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/spelling/suggest/SafariInfixSuggesterTest.java
@@ -1,0 +1,154 @@
+package com.ifactory.press.db.solr.spelling.suggest;
+
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.util.BytesRef;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class SafariInfixSuggesterTest {
+
+  private SafariInfixSuggester suggester;
+
+  @Before
+  public void startup() throws Exception {
+    // Initialize SafariInfixSuggester with empty suggestions
+    WhitespaceAnalyzer analyzer = new WhitespaceAnalyzer();
+    Directory dir = new RAMDirectory();
+    String[] excludedContexts = {"collection", "certification"};
+    suggester = new SafariInfixSuggester(dir, analyzer, analyzer, 0, true, Arrays.asList(excludedContexts));
+  }
+
+  private void addSuggestion(String text, String[] contexts, int weight, BytesRef payload) throws IOException {
+    Set<BytesRef> contextSet = new HashSet<>();
+    if(contexts != null) {
+      for (String context : contexts) {
+        contextSet.add(new BytesRef(context));
+      }
+    }
+    suggester.add(new BytesRef(text), contextSet, weight, payload);
+  }
+
+  private int getSuggestionCount() {
+    return suggester.getSuggestWeightMap().size();
+  }
+
+  private Long getSuggestionWeight(String suggestText) {
+    Suggestion suggestion = new Suggestion(suggestText, null, 0, null);
+    return suggester.getSuggestWeightMap().get(suggestion);
+  }
+
+  @Test
+  public void testAddBasicSuggest() throws IOException {
+    // Adding a basic suggestion without additional data
+    addSuggestion("python", null, 0, null);
+    assertEquals(1, getSuggestionCount());
+  }
+
+  @Test
+  public void testAddMultipleSuggestions() throws IOException {
+    addSuggestion("python", null, 0, null);
+    addSuggestion("java", null, 0, null);
+    addSuggestion("c++", null, 0, null);
+    assertEquals(3, getSuggestionCount());
+  }
+
+  @Test
+  public void testAddSuggestionsWithContext() throws IOException {
+    // Adding basic suggestions with multiple contexts
+    addSuggestion("python", new String[]{"book", "en"}, 0, null);
+    addSuggestion("java video", new String[]{"video", "en"}, 0, null);
+    assertEquals(2, getSuggestionCount());
+  }
+
+  @Test
+  public void testAddSuggestionsWithPayload() throws IOException {
+    // Adding basic suggestions with payloads
+    addSuggestion("python", new String[]{"book", "en"}, 0, new BytesRef("book"));
+    addSuggestion("java video", new String[]{"video", "en"}, 0, new BytesRef("video"));
+    addSuggestion("c++", new String[]{"video", "en"}, 0, new BytesRef("video"));
+    assertEquals(3, getSuggestionCount());
+  }
+
+  @Test
+  public void testAddDuplicateSuggestions() throws IOException {
+    // Suggest HashMap should filter out duplicates
+    addSuggestion("python", null, 0, null);
+    addSuggestion("java", null, 0, null);
+    addSuggestion("python", null, 0, null);
+    assertEquals(2, getSuggestionCount());
+  }
+
+  @Test
+  public void testAddDupeSuggestionsDifferentFormatContext() throws IOException {
+    // Suggest HashMap should include duplicate suggest text if format contexts are different
+    addSuggestion("python", new String[]{"book"}, 10, null);
+    addSuggestion("python", new String[]{"video"}, 50, null);
+    addSuggestion("python", new String[]{"learning path"}, 100, null);
+    assertEquals(3, getSuggestionCount());
+  }
+
+  @Test
+  public void testAddDupeSuggestionsDifferentContext() throws IOException {
+    // Suggest HashMap should include duplicate suggest text if multiple context fields are different
+    addSuggestion("python", new String[]{"book", "en"}, 0, null);
+    addSuggestion("java video", new String[]{"video", "en"}, 0, null);
+    addSuggestion("python", new String[]{"video", "en"}, 0, null);
+    assertEquals(3, getSuggestionCount());
+  }
+
+  @Test
+  public void testAddDupeSuggestionsDifferentPayload() throws IOException {
+    // Payloads are strictly to transfer data, should not be used when deciding if suggestions are duplicates
+    addSuggestion("python", new String[]{"book", "en"}, 0, new BytesRef("payload"));
+    addSuggestion("python", new String[]{"book", "en"}, 0, new BytesRef("test"));
+    assertEquals(1, getSuggestionCount());
+  }
+
+  @Test
+  public void testDuplicateContextsDifferentText() throws IOException {
+    // Two suggestions with the same context but different text should not considered duplicates
+    addSuggestion("python", new String[]{"book", "en"}, 0, null);
+    addSuggestion("java", new String[]{"book", "en"}, 0, null);
+    assertEquals(2, getSuggestionCount());
+  }
+
+  @Test
+  public void testDuplicateSuggestionKeepsHighestWeight() throws IOException {
+    // When de-duping suggestions, suggestion should always keep the highest weight
+    addSuggestion("python", null, 10, null);
+    addSuggestion("python", null, 100, null);
+    addSuggestion("python", null, 50, null);
+    assertEquals(1, getSuggestionCount());
+    assertEquals(Long.valueOf(100), getSuggestionWeight("python"));
+  }
+
+  @Test
+  public void testContextWithHyphen() throws IOException {
+    // Hyphens should persist and be treated as normal text when used in suggest contexts
+    addSuggestion("python", new String[]{"book", "en-us"}, 0, null);
+    addSuggestion("java video", new String[]{"video", "en"}, 0, null);
+    addSuggestion("python", new String[]{"video", "en"}, 0, null);
+    addSuggestion("python", new String[]{"video", "en-gb"}, 0, null);
+    addSuggestion("python", new String[]{"book", "en-us"}, 0, null);
+    assertEquals(4, getSuggestionCount());
+  }
+
+  @Test
+  public void testExcludedContextsNotBuilt() throws IOException {
+    // Suggestions with excluded contexts should not be included in the build, regardless of suggest text
+    addSuggestion("python", new String[]{"book", "en-us"}, 0, null);
+    addSuggestion("java", new String[]{"video", "en"}, 0, null);
+    addSuggestion("python", new String[]{"collection", "en"}, 0, null);
+    addSuggestion("c++", new String[]{"certification", "en-gb"}, 0, null);
+    addSuggestion("python", new String[]{"collection"}, 0, null);
+    assertEquals(2, getSuggestionCount());
+  }
+}


### PR DESCRIPTION
* Added `excludeContexts` as an optional param for Suggesters to exclude suggestions with any of those contexts at build time. This can be used to exclude playlists, scenarios, etc... in suggest build instead of relying solely on context filter queries.
* Added unit testing for SafariInfixSuggester
* Cleaned up configs and other tests/files