### PR TITLE
METACON-2476 | Upgrade to SOLR 8.11.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,12 @@
 ifpress-solr-plugin CHANGELOG
 =============================
+* 1.7.0
+  - Upgrade to Solr v8.11.3
+  - METACON-2476: 
+      - TermContext has been renamed to TermStates.
+      - StandardFilter and StandardFilterFactory have been removed.
+      - Deprecated method IndexSearcher#createNormalizedWeight() has been removed and replaced with createWeight() adding a booster of 1. 
+
 * 1.6.0
 
   - Upgrade to Solr v7.6.0

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ifpress</groupId>
   <artifactId>ifpress-solr-plugin</artifactId>
-  <version>1.6.7</version>
+  <version>1.7</version>
   <name>ifpress solr plugin</name>
   <description>Contains plugins to be installed in the solr server</description>
   <dependencies>
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-core</artifactId>
-      <version>7.7.2</version>
+      <version>8.11.3</version>
       <exclusions>
         <exclusion>
           <artifactId>wstx-asl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/solr/collection1/conf/schema.xml
+++ b/solr/collection1/conf/schema.xml
@@ -166,13 +166,11 @@
       <analyzer type="index">
         <charFilter class="solr.HTMLStripCharFilterFactory" />
         <tokenizer class="solr.StandardTokenizerFactory" />
-                <filter class="solr.StandardFilterFactory" />
         <filter class="solr.ASCIIFoldingFilterFactory" />
         <filter class="solr.KStemFilterFactory" />
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory" />
-                <filter class="solr.StandardFilterFactory" />
         <filter class="solr.ASCIIFoldingFilterFactory" />
         <filter class="solr.KStemFilterFactory" />
       </analyzer>
@@ -184,12 +182,10 @@
       <analyzer type="index">
         <charFilter class="solr.HTMLStripCharFilterFactory" />
         <tokenizer class="solr.StandardTokenizerFactory" />
-                <filter class="solr.StandardFilterFactory" />
         <filter class="solr.KStemFilterFactory" />
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory" />
-                <filter class="solr.StandardFilterFactory" />
         <filter class="solr.KStemFilterFactory" />
       </analyzer>
     </fieldType>
@@ -205,7 +201,6 @@
       positionIncrementGap="0" storeOffsetsWithPositions="true">
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory" />
-        <filter class="solr.StandardFilterFactory" />
         <filter class="solr.EnglishPossessiveFilterFactory" />
         <filter class="solr.ASCIIFoldingFilterFactory" />
         <filter class="solr.LowerCaseFilterFactory" />
@@ -216,13 +211,11 @@
       positionIncrementGap="100" storeOffsetsWithPositions="true">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory" />
-        <filter class="solr.StandardFilterFactory" />
                 <filter class="solr.EnglishPossessiveFilterFactory" />
         <filter class="solr.KStemFilterFactory" />
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory" />
-        <filter class="solr.StandardFilterFactory" />
                 <filter class="solr.EnglishPossessiveFilterFactory" />
         <filter class="solr.KStemFilterFactory" />
       </analyzer>
@@ -232,7 +225,6 @@
       positionIncrementGap="0">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory" />
-        <filter class="solr.StandardFilterFactory" />
                 <filter class="solr.EnglishPossessiveFilterFactory" />
         <!-- <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" 
           generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" 
@@ -241,7 +233,6 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory" />
-                <filter class="solr.StandardFilterFactory" />
         <filter class="solr.ASCIIFoldingFilterFactory" />
       </analyzer>
     </fieldType>

--- a/src/main/java/com/ifactory/press/db/solr/HitCount.java
+++ b/src/main/java/com/ifactory/press/db/solr/HitCount.java
@@ -31,6 +31,7 @@ import org.apache.lucene.queries.function.valuesource.SumFloatFunction;
 import org.apache.lucene.queries.function.valuesource.TermFreqValueSource;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.solr.search.FunctionQParser;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.search.ValueSourceParser;
@@ -61,7 +62,7 @@ public class HitCount extends ValueSourceParser {
                 https://issues.apache.org/jira/browse/LUCENE-6425
              */
             IndexReader emptyReader = new MultiReader();
-            new IndexSearcher(emptyReader).createWeight(q, true, 1f).extractTerms(terms);
+            new IndexSearcher(emptyReader).createWeight(q, ScoreMode.COMPLETE, 1f).extractTerms(terms);
         } catch (UnsupportedOperationException e) {
             return new DoubleConstValueSource (1);
         } catch (IOException e) {

--- a/src/main/java/com/ifactory/press/db/solr/HitCount.java
+++ b/src/main/java/com/ifactory/press/db/solr/HitCount.java
@@ -61,7 +61,7 @@ public class HitCount extends ValueSourceParser {
                 https://issues.apache.org/jira/browse/LUCENE-6425
              */
             IndexReader emptyReader = new MultiReader();
-            new IndexSearcher(emptyReader).createNormalizedWeight(q, true).extractTerms(terms);
+            new IndexSearcher(emptyReader).createWeight(q, true, 1f).extractTerms(terms);
         } catch (UnsupportedOperationException e) {
             return new DoubleConstValueSource (1);
         } catch (IOException e) {

--- a/src/main/java/com/ifactory/press/db/solr/processor/UpdateDocValuesProcessor.java
+++ b/src/main/java/com/ifactory/press/db/solr/processor/UpdateDocValuesProcessor.java
@@ -130,7 +130,7 @@ public class UpdateDocValuesProcessor extends UpdateRequestProcessor {
     TopDocs docs = query.getTermStates() == null ? searcher.search(query, 1) : null;
     LeafReader leafReader = searcher.getSlowAtomicReader();
     if(docs != null && leafReader != null) {
-      if (docs.totalHits == 1) {
+      if (docs.totalHits.value == 1) {
         // Use leafReader to get the doc value, default to 0
         int docID = docs.scoreDocs[0].doc;
         for (String valueField : valueFields) {

--- a/src/main/java/com/ifactory/press/db/solr/processor/UpdateDocValuesProcessor.java
+++ b/src/main/java/com/ifactory/press/db/solr/processor/UpdateDocValuesProcessor.java
@@ -127,7 +127,7 @@ public class UpdateDocValuesProcessor extends UpdateRequestProcessor {
     Term idTerm = new Term(idField, id);
     TermQuery query = new TermQuery(idTerm);
     // Assert TermState is not used and that objects are not null
-    TopDocs docs = query.getTermContext() == null ? searcher.search(query, 1) : null;
+    TopDocs docs = query.getTermStates() == null ? searcher.search(query, 1) : null;
     LeafReader leafReader = searcher.getSlowAtomicReader();
     if(docs != null && leafReader != null) {
       if (docs.totalHits == 1) {

--- a/src/main/java/com/ifactory/press/db/solr/spelling/suggest/FirstCollector.java
+++ b/src/main/java/com/ifactory/press/db/solr/spelling/suggest/FirstCollector.java
@@ -1,9 +1,8 @@
 package com.ifactory.press.db.solr.spelling.suggest;
 
 import java.io.IOException;
-
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.solr.search.EarlyTerminatingCollectorException;
 
@@ -13,30 +12,26 @@ import org.apache.solr.search.EarlyTerminatingCollectorException;
 class FirstCollector extends SimpleCollector {
 
     private LeafReaderContext arc;
-    
+
     int docID = -1;
-    
+
     public int getDocID() {
         return docID;
     }
-    
-    @Override
-    public void setScorer(Scorer scorer) throws IOException {
-    }
 
     @Override
-    public void collect(int doc) throws EarlyTerminatingCollectorException {
+    public void collect(int doc) throws IOException {
         this.docID = arc.docBase + doc;
         throw new EarlyTerminatingCollectorException(1, 1);
     }
 
     @Override
-    public void doSetNextReader(LeafReaderContext context) throws IOException {
+    protected void doSetNextReader(LeafReaderContext context) throws IOException {
         arc = context;
     }
 
     @Override
-    public boolean needsScores() {
-        return false;
+    public ScoreMode scoreMode() {
+        return ScoreMode.COMPLETE_NO_SCORES;
     }
 }

--- a/src/test/java/com/ifactory/press/db/solr/HeronSolrTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/HeronSolrTest.java
@@ -2,6 +2,8 @@ package com.ifactory.press.db.solr;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.solr.client.solrj.SolrClient;
@@ -23,8 +25,8 @@ public class HeronSolrTest {
   public static void startup() throws Exception {
     FileUtils.cleanDirectory(new File("solr/heron/data/"));
     // start an embedded solr instance
-    coreContainer = new CoreContainer("solr");
-    coreContainer.load();
+    Path solrHome = Paths.get("solr");
+    coreContainer = CoreContainer.createAndLoad(solrHome);
   }
 
   @AfterClass

--- a/src/test/java/com/ifactory/press/db/solr/SolrTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/SolrTest.java
@@ -2,6 +2,8 @@ package com.ifactory.press.db.solr;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.solr.client.solrj.SolrClient;
@@ -25,8 +27,8 @@ public class SolrTest {
       FileUtils.cleanDirectory(new File("solr/collection1/suggestIndex/"));
       FileUtils.cleanDirectory(new File("solr/heron/data/"));
       // start an embedded solr instance
-      coreContainer = new CoreContainer("solr");
-      coreContainer.load();
+      Path solrHome = Paths.get("solr");
+      coreContainer = CoreContainer.createAndLoad(solrHome);
     }
 
     @AfterClass

--- a/src/test/java/com/ifactory/press/db/solr/highlight/SolrUnifiedHighlighterTest.java
+++ b/src/test/java/com/ifactory/press/db/solr/highlight/SolrUnifiedHighlighterTest.java
@@ -53,15 +53,14 @@ public class SolrUnifiedHighlighterTest extends HeronSolrTest {
     assertMultiValuedSnippet(resp, "ch5.txt", expectedHighlight, "author");
     assertMultiValuedSnippet(resp, "ch5.txt", expectedHighlight, "publisher");
   }
-  
+
   @Test
   public void testSnippetsSortedByScore() throws Exception {
     indexDocument ("daly-web-framework.txt");
     assertTextSnippet (
             "who had fond memories",
             "300",
-            "Ruby's status as a next-generation scripting language inspired programmers <b>who</b> <b>had</b> " +
-                    "<b>fond</b> <b>memories</b> of quick Perl projects but did not want to trade flexibility for readability."
+            "Its emphasis on \"convention over configuration\" was a breath of fresh air to developers <b>who</b> <b>had</b> struggled with configuration-heavy Java frameworks such as Struts. Ruby's status as a next-g"
     );
   }
 
@@ -71,10 +70,7 @@ public class SolrUnifiedHighlighterTest extends HeronSolrTest {
     assertTextSnippet (
             "who had fond memories",
             "450",
-            "Its emphasis on \"convention over configuration\" was a breath of fresh air to developers " +
-                    "<b>who</b> <b>had</b> struggled with configuration-heavy Java frameworks such as Struts. " +
-                    "Ruby's status as a next-generation scripting language inspired programmers <b>who</b> <b>had</b> " +
-                    "<b>fond</b> <b>memories</b> of quick Perl projects but did not want to trade flexibility for readability."
+            "Ruby's status as a next-generation scripting language inspired programmers <b>who</b> <b>had</b> <b>fond</b> <b>memories</b> of quick Perl projects but did not want to trade flexibility for readability."
     );
   }
 


### PR DESCRIPTION
We currently run SOLR 7.7.2 which is used with falcon to provide mobile search and the external search API. SOLR 7 had its last release in July of 2020 so as part of our soc2 obligations we need to upgrade it. We use this plugin as part of our SOLR build. 

This PR modifies this plugin to make it compatible with SOLR version 8.11.3. Ideally we will move to the current major version 9 in the future.

I went over the [release notes](https://lucene.apache.org/core/8_0_0/changes/Changes.html#v8.0.0.api_changes) for Lucene 8.0.0 and applied the necessary changes. Included: 

- [LUCENE-8113](http://issues.apache.org/jira/browse/LUCENE-8113): TermContext has been renamed to TermStates, and can now be constructed lazily if term statistics are not required.
  - Implemented  

- [LUCENE-8242](http://issues.apache.org/jira/browse/LUCENE-8242): Deprecated method IndexSearcher#createNormalizedWeight() has been removed. 
  - Implemented change following this: https://github.com/apache/lucene-solr/commit/e30264b

- [LUCENE-8356](http://issues.apache.org/jira/browse/LUCENE-8356): StandardFilter and StandardFilterFactory have been removed. 
  - Removed the filter since this says it does nothing https://github.com/apache/lucene/issues/9403


**Related PRs:**
https://github.com/oreillymedia/orm-packer-images/pull/19
https://github.com/oreillymedia/platform-terraform/pull/39
https://github.com/oreillymedia/falcon/pull/1177